### PR TITLE
Not all comments are displayed 

### DIFF
--- a/public/tendersmash.js
+++ b/public/tendersmash.js
@@ -359,6 +359,9 @@ app.controller("mainController", function ($scope, $http, $sce, $q, $timeout, pr
     _.each(disccussions, function (disccussion) {
       promises.push($http.get(disccussion.href)
           .then(function(response) {
+            // There is no way for us to know whether we have all comments and retrieving them separately for all discussion doubles the load time
+            // so we have this workaround in place.
+            if (!response.data.comments || response.data.comments.length <= 20) return response;
             var baseUrl = response.data.comments_href.replace("{?page}", "");
             return $scope.getComments(baseUrl)
                 .then(function(comments) {

--- a/public/tendersmash.js
+++ b/public/tendersmash.js
@@ -338,6 +338,22 @@ app.controller("mainController", function ($scope, $http, $sce, $q, $timeout, pr
     }
   };
 
+  $scope.getComments = function(baseUrl, currentPage) {
+    if (!currentPage) currentPage = 1;
+    return $http.get(baseUrl + "?page=" + currentPage)
+                .then(function(currentPageResponse) {
+                  if (currentPageResponse.data.comments) {
+                    return $scope.getComments(baseUrl, currentPage + 1)
+                                .then(function(nextPageComments) {
+                                  var comments = currentPageResponse.data.comments.concat(nextPageComments);
+                                  return $q.when(comments);
+                                });
+                  } else {
+                    return $q.when([]);
+                  }
+                });
+  }
+
   $scope.reload = function() {
     $scope.currentDiscussion = null;
     $scope.currentList = null;
@@ -398,11 +414,29 @@ app.controller("mainController", function ($scope, $http, $sce, $q, $timeout, pr
             var pendingAssigned = _.filter(pendingDiscussionListing.discussions, function (d) { return d.cached_queue_list.length > 0; });
             
             _.each(pendingUnassigned, function (d) {
-              unassignedPromises.push($http.get(d.href).success(function (data) { return data; }));
+              unassignedPromises.push($http.get(d.href)
+                                            .then(function(response) {
+                                              var baseUrl = response.data.comments_href.replace("{?page}", "");
+                                              return $scope.getComments(baseUrl)
+                                                            .then(function(comments) {
+                                                              response.data.comments = comments;
+                                                              return $q.when(response);
+                                                            });
+                                            }));
+
             });
             
             _.each(pendingAssigned, function (discus) {
-              promises.push($http.get(discus.href).success(function (data) { return data; }));
+              promises.push($http.get(discus.href)
+                                  .then(function(response) {
+                                      var baseUrl = response.data.comments_href.replace("{?page}", "");
+                                      return $scope.getComments(baseUrl)
+                                                    .then(function(comments) {
+                                                      response.data.comments = comments;
+                                                      return $q.when(response);
+                                                    });
+                                  }));
+                                  //.success(function (data) { return data; }));
             });
 
             console.debug('[' + (new Date()).toLocaleString() + '] Retrieving unassigned discussions...');


### PR DESCRIPTION
Fixes #9

It turns out that the Discussion resource might not provide all comments. The docs are vague on this subject. This means we need to retrive them separately using Comments resource. This works but it means that we need to double the number of calls we are making when the app loads. On my machine this means that the load time jumps from **11.5** seconds to **21** seconds. 

We could try to guess whether we already have all comments (the ones that come with Discussion resource) but Discussion.comments includes also other type of messages so for the sample url included in the origianl issue Discussion.comments_count is 29, Discussion.comments contains 31 elements and still it does not include the second page of comments. 

Is that a good enough solution?
